### PR TITLE
Detect unique dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/bcd46487fd2c4b79b930556275eec3d4)](https://www.codacy.com/app/reallyinsane/mathan-dependency-updates-sonar-plugin?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=reallyinsane/mathan-dependency-updates-sonar-plugin&amp;utm_campaign=Badge_Grade)
 <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/license-apache2-blue.svg"></a>
 
-# Dependency-Updates-Report Plugin for SonarQube 7.6 - 7.9
+# Dependency-Updates-Report Plugin for SonarQube 7.9
 
-Integrates [dependency updates report] from [versions-maven-plugin] into SonarQube v7.6 - 7.9.
+Integrates [dependency updates report] from [versions-maven-plugin] into SonarQube v7.9.
 
 ## About dependency updates report
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ Dependencies to patch | The number of dependencies with patches available (incre
 Dependencies to patch (Ratio) | The ratio of dependencies to patch. 
 Dependencies to upgrade | The number of dependencies with upgrades available (minor and/or major updates).
 Dependencies to upgrade (Ratio) | The ratio of dependencies to upgrade.
+Dependencies Total | The total number of dependencies.
 Patch maintenance | The rating of the patch maintenance (see below)
 Patches missed | The total number of patches missed. 
 Upgrade maintenance | The rating of the upgrade maintenance (see below)
 Upgrades missed | The total number of upgrades missed. 
+
+Please note that when computing measures on directory/module/project level measures for identical dependencies will be included only once. E.g. if a project contains two sub models having same
+dependency, this is included in the measure for each sub module. For the project the measure will not include the dependency multiple times (for each sub module) but only once.
 
 #### Maintenance rating
 
@@ -69,7 +73,18 @@ whose group id started with `org.apache.`, and `:::*-SNAPSHOT` would match all s
 
 ### Configuration properties
 
-This plugin offers various configuration options which are explained in the following categories.
+This plugin offers various configuration options which are explained in the following categories. The settings can be found under Administration > Configuration > General Settings > Dependency-Updates.
+
+#### Appearance
+
+By default 9 metrics will be reported. With the following configuration metrics for ratio, rating and missed patches/upgrades can be hidden. Changes to the setting in this category need a restart of
+ SonarQube to take effect.
+ 
+Property | Default
+---------|--------
+Hide missed measures | false
+Hide rating measures | false
+Hide ratio mesasures | false 
 
 #### Default Severity
 

--- a/mathan-dependency-updates-sonar-plugin/pom.xml
+++ b/mathan-dependency-updates-sonar-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.mathan.sonar</groupId>
     <artifactId>mathan-dependency-updates-sonar-plugin-reactor</artifactId>
-    <version>7.6.0-SNAPSHOT</version>
+    <version>7.9.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>mathan-dependency-updates-sonar-plugin</artifactId>

--- a/mathan-dependency-updates-sonar-plugin/pom.xml
+++ b/mathan-dependency-updates-sonar-plugin/pom.xml
@@ -10,13 +10,6 @@
   </parent>
   <artifactId>mathan-dependency-updates-sonar-plugin</artifactId>
   <packaging>sonar-plugin</packaging>
-  <properties>
-    <sonar.version>7.6</sonar.version>
-    <!-- Configuration for sonar-packaging-maven-plugin -->
-    <sonar.pluginClass>io.mathan.sonar.dependencyupdates.Plugin</sonar.pluginClass>
-    <sonar.pluginName>Dependency-Updates</sonar.pluginName>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
@@ -27,7 +20,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.8.1</version>
+      <version>3.9</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.staxmate</groupId>
@@ -60,8 +53,9 @@
     </dependency>
     <dependency> <!-- use a specific Groovy version rather than the one specified by spock-core -->
       <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
-      <version>2.4.16</version>
+      <artifactId>groovy</artifactId>
+      <scope>test</scope>
+      <version>2.5.8</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -84,7 +78,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>27.1-jre</version>
+      <version>28.1-jre</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -94,6 +88,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <properties>
+    <sonar.version>7.9.1</sonar.version>
+    <!-- Configuration for sonar-packaging-maven-plugin -->
+    <sonar.pluginClass>io.mathan.sonar.dependencyupdates.Plugin</sonar.pluginClass>
+    <sonar.pluginName>Dependency-Updates</sonar.pluginName>
+  </properties>
   <build>
     <plugins>
       <plugin>
@@ -105,7 +106,6 @@
         <executions>
           <execution>
             <goals>
-              <goal>compile</goal>
               <goal>compileTests</goal>
             </goals>
           </execution>

--- a/mathan-dependency-updates-sonar-plugin/src/main/java/io/mathan/sonar/dependencyupdates/Configuration.java
+++ b/mathan-dependency-updates-sonar-plugin/src/main/java/io/mathan/sonar/dependencyupdates/Configuration.java
@@ -47,6 +47,7 @@ public class Configuration {
             .options(Severity.ALL)
             .defaultValue(Constants.CONFIG_UPDATE_INCREMENTAL_DEFAULT)
             .type(PropertyType.SINGLE_SELECT_LIST)
+            .index(1)
             .build(),
         PropertyDefinition.builder(Constants.CONFIG_UPDATE_MINOR)
             .subCategory(Constants.SUB_CATEGORY_DEFAULT_SEVERITIES)
@@ -55,6 +56,7 @@ public class Configuration {
             .options(Severity.ALL)
             .defaultValue(Constants.CONFIG_UPDATE_MINOR_DEFAULT)
             .type(PropertyType.SINGLE_SELECT_LIST)
+            .index(2)
             .build(),
         PropertyDefinition.builder(Constants.CONFIG_UPDATE_MAJOR)
             .subCategory(Constants.SUB_CATEGORY_DEFAULT_SEVERITIES)
@@ -63,6 +65,7 @@ public class Configuration {
             .options(Severity.ALL)
             .defaultValue(Constants.CONFIG_UPDATE_MAJOR_DEFAULT)
             .type(PropertyType.SINGLE_SELECT_LIST)
+            .index(3)
             .build(),
         PropertyDefinition.builder(Constants.CONFIG_INCLUSIONS)
             .subCategory(Constants.SUB_CATEGORY_INCLUSIONS_EXCLUSIONS)
@@ -72,6 +75,7 @@ public class Configuration {
                 + " and partial * wildcards. Ab empty pattern segment is treated as an implicit wildcard *.")
             .defaultValue("")
             .type(PropertyType.STRING)
+            .index(1)
             .build(),
         PropertyDefinition.builder(Constants.CONFIG_EXCLUSIONS)
             .subCategory(Constants.SUB_CATEGORY_INCLUSIONS_EXCLUSIONS)
@@ -81,6 +85,7 @@ public class Configuration {
                 + " and partial * wildcards. Ab empty pattern segment is treated as an implicit wildcard *.")
             .defaultValue("")
             .type(PropertyType.STRING)
+            .index(2)
             .build(),
         PropertyDefinition.builder(Constants.CONFIG_OVERRIDE_INFO)
             .subCategory(Constants.SUB_CATEGORY_OVERRIDES)
@@ -88,6 +93,7 @@ public class Configuration {
             .description("Whitelist of dependencies whose issue severity will be overridden with INFO. The filter syntax is"
                 + " [groupId]:[artifactId]:[type]:[version] where each pattern segment is optional and supports full"
                 + " and partial * wildcards. Ab empty pattern segment is treated as an implicit wildcard *.")
+            .index(1)
             .build(),
         PropertyDefinition.builder(Constants.CONFIG_OVERRIDE_MINOR)
             .subCategory(Constants.SUB_CATEGORY_OVERRIDES)
@@ -95,6 +101,7 @@ public class Configuration {
             .description("Whitelist of dependencies whose issue severity will be overridden with MINOR. The filter syntax is"
                 + " [groupId]:[artifactId]:[type]:[version] where each pattern segment is optional and supports full"
                 + " and partial * wildcards. Ab empty pattern segment is treated as an implicit wildcard *.")
+            .index(2)
             .build(),
         PropertyDefinition.builder(Constants.CONFIG_OVERRIDE_MAJOR)
             .subCategory(Constants.SUB_CATEGORY_OVERRIDES)
@@ -102,6 +109,7 @@ public class Configuration {
             .description("Whitelist of dependencies whose issue severity will be overridden with MAJOR. The filter syntax is"
                 + " [groupId]:[artifactId]:[type]:[version] where each pattern segment is optional and supports full"
                 + " and partial * wildcards. Ab empty pattern segment is treated as an implicit wildcard *.")
+            .index(3)
             .build(),
         PropertyDefinition.builder(Constants.CONFIG_OVERRIDE_CRITICAL)
             .subCategory(Constants.SUB_CATEGORY_OVERRIDES)
@@ -109,6 +117,7 @@ public class Configuration {
             .description("Whitelist of dependencies whose issue severity will be overridden with CRITICAL. The filter syntax is"
                 + " [groupId]:[artifactId]:[type]:[version] where each pattern segment is optional and supports full"
                 + " and partial * wildcards. Ab empty pattern segment is treated as an implicit wildcard *.")
+            .index(4)
             .build(),
         PropertyDefinition.builder(Constants.CONFIG_OVERRIDE_BLOCKER)
             .subCategory(Constants.SUB_CATEGORY_OVERRIDES)
@@ -116,6 +125,7 @@ public class Configuration {
             .description("Whitelist of dependencies whose issue severity will be overridden with BLOCKER. The filter syntax is"
                 + " [groupId]:[artifactId]:[type]:[version] where each pattern segment is optional and supports full"
                 + " and partial * wildcards. Ab empty pattern segment is treated as an implicit wildcard *.")
+            .index(5)
             .build(),
         PropertyDefinition.builder(Constants.CONFIG_VERSION_EXCLUSION_REGEX)
             .subCategory(Constants.SUB_CATEGORY_VERSIONS)

--- a/mathan-dependency-updates-sonar-plugin/src/main/java/io/mathan/sonar/dependencyupdates/Configuration.java
+++ b/mathan-dependency-updates-sonar-plugin/src/main/java/io/mathan/sonar/dependencyupdates/Configuration.java
@@ -134,6 +134,27 @@ public class Configuration {
                 + " result would be 2 (1.1.2 and 1.2.0) and in case of 'false' 4 (all available versions).")
             .type(PropertyType.BOOLEAN)
             .defaultValue("true")
+            .build(),
+        PropertyDefinition.builder(Constants.CONFIG_MEASURE_HIDE_RATIO)
+            .subCategory(Constants.SUB_CATEGORY_APPEARANCE)
+            .name("Hide ratio measures")
+            .description("Flag indicating whether the ratio measure for dependencies to update/upgrade will be hidden. (Change requires restart)")
+            .type(PropertyType.BOOLEAN)
+            .defaultValue(String.valueOf(Constants.CONFIG_MEASURE_HIDE_RATIO_DEFAULT))
+            .build(),
+        PropertyDefinition.builder(Constants.CONFIG_MEASURE_HIDE_RATING)
+            .subCategory(Constants.SUB_CATEGORY_APPEARANCE)
+            .name("Hide rating measures")
+            .description("Flag indicating whether the rating measure for dependencies to update/upgrade will be hidden. (Change requires restart)")
+            .type(PropertyType.BOOLEAN)
+            .defaultValue(String.valueOf(Constants.CONFIG_MEASURE_HIDE_RATING_DEFAULT))
+            .build(),
+        PropertyDefinition.builder(Constants.CONFIG_MEASURE_HIDE_MISSED)
+            .subCategory(Constants.SUB_CATEGORY_APPEARANCE)
+            .name("Hide missed measures")
+            .description("Flag indicating whether the total number of missed patches/upgrades measure will be hidden. (Change requires restart)")
+            .type(PropertyType.BOOLEAN)
+            .defaultValue(String.valueOf(Constants.CONFIG_MEASURE_HIDE_MISSED_DEFAULT))
             .build()
     );
   }

--- a/mathan-dependency-updates-sonar-plugin/src/main/java/io/mathan/sonar/dependencyupdates/Constants.java
+++ b/mathan-dependency-updates-sonar-plugin/src/main/java/io/mathan/sonar/dependencyupdates/Constants.java
@@ -46,6 +46,15 @@ public final class Constants {
   public static final String CONFIG_DISCRETE_MINOR_MAJOR = "sonar.dependencyUpdates.discreteMinorMajor";
   public static final Boolean CONFIG_DISCRETE_MINOR_MAJOR_DEFAULT = true;
 
+  static final String CONFIG_MEASURE_HIDE_RATIO = "sonar.dependencyUpdates.hide.ratio";
+  static final Boolean CONFIG_MEASURE_HIDE_RATIO_DEFAULT = false;
+  static final String CONFIG_MEASURE_HIDE_MISSED = "sonar.dependencyUpdates.hide.missed";
+  static final Boolean CONFIG_MEASURE_HIDE_MISSED_DEFAULT = false;
+  static final String CONFIG_MEASURE_HIDE_RATING = "sonar.dependencyUpdates.hide.rating";
+  static final Boolean CONFIG_MEASURE_HIDE_RATING_DEFAULT = false;
+
+
+
 
   public static final String REPOSITORY_KEY = "DependencyUpdates";
   public static final String LANGUAGE_KEY = "mathan";
@@ -54,6 +63,7 @@ public final class Constants {
   static final String SUB_CATEGORY_INCLUSIONS_EXCLUSIONS = "Inclusions/Exclusions";
   static final String SUB_CATEGORY_OVERRIDES = "Overrides";
   static final String SUB_CATEGORY_VERSIONS = "Versions";
+  static final String SUB_CATEGORY_APPEARANCE = "Appearance";
 
   private Constants() {
   }

--- a/mathan-dependency-updates-sonar-plugin/src/main/java/io/mathan/sonar/dependencyupdates/Metrics.java
+++ b/mathan-dependency-updates-sonar-plugin/src/main/java/io/mathan/sonar/dependencyupdates/Metrics.java
@@ -30,24 +30,23 @@ import org.sonar.api.batch.fs.InputComponent;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.measures.Metric;
 import org.sonar.api.measures.Metric.ValueType;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
 
 public final class Metrics implements org.sonar.api.measures.Metrics {
 
-  private static final Logger LOGGER = Loggers.get(Metrics.class);
-
   private static final String DOMAIN = "Dependency Updates";
 
-  public static final String KEY_DEPENDENCIES = "metrics.dependencies";
-  public static final String KEY_PATCHES = "metrics.patches";
-  public static final String KEY_PATCHES_RATIO = "metrics.patches.ratio";
-  public static final String KEY_PATCHES_MISSED = "metrics.patches.repeatedly";
-  public static final String KEY_PATCHES_RATING = "metrios.patches.rating";
-  public static final String KEY_UPGRADES = "metrics.upgrades";
-  public static final String KEY_UPGRADES_RATIO = "metrics.upgrades.ratio";
-  public static final String KEY_UPGRADES_MISSED = "metrics.upgrades.repeatedly";
-  public static final String KEY_UPGRADES_RATING = "metrios.upgrades.rating";
+  static final String KEY_DEPENDENCIES = "metrics.dependencies";
+  static final String KEY_DEPENDENCIES_DATA = "metrics.dependencies.data";
+  static final String KEY_PATCHES = "metrics.patches";
+  static final String KEY_PATCHES_DATA = "metrics.patches.data";
+  static final String KEY_PATCHES_RATIO = "metrics.patches.ratio";
+  static final String KEY_PATCHES_MISSED = "metrics.patches.repeatedly";
+  static final String KEY_PATCHES_RATING = "metrios.patches.rating";
+  static final String KEY_UPGRADES = "metrics.upgrades";
+  static final String KEY_UPGRADES_DATA = "metrics.upgrades.data";
+  static final String KEY_UPGRADES_RATIO = "metrics.upgrades.ratio";
+  static final String KEY_UPGRADES_MISSED = "metrics.upgrades.repeatedly";
+  static final String KEY_UPGRADES_RATING = "metrios.upgrades.rating";
 
   private static final int RATING_A = 1;
   private static final int RATING_B = 2;
@@ -93,7 +92,7 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
   }
 
 
-  static final Metric<Integer> DEPENDENCIES = new Metric.Builder(Metrics.KEY_DEPENDENCIES, "Total dependencies", ValueType.INT)
+  private static final Metric<Integer> DEPENDENCIES = new Metric.Builder(Metrics.KEY_DEPENDENCIES, "Total dependencies", ValueType.INT)
       .setDescription("Total number of dependencies")
       .setDirection(Metric.DIRECTION_NONE)
       .setQualitative(Boolean.FALSE)
@@ -101,7 +100,15 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
       .setHidden(false)
       .create();
 
-  static final Metric<Integer> PATCHES = new Metric.Builder(Metrics.KEY_PATCHES, "Dependencies to patch", ValueType.INT)
+  private static final Metric<String> DEPENDENCIES_DATA = new Metric.Builder(Metrics.KEY_DEPENDENCIES_DATA, "List of dependencies", ValueType.STRING)
+      .setDescription("All dependencies concatenated in a list")
+      .setDirection(Metric.DIRECTION_NONE)
+      .setQualitative(false)
+      .setDomain(Metrics.DOMAIN)
+      .setHidden(true)
+      .create();
+
+  private static final Metric<Integer> PATCHES = new Metric.Builder(Metrics.KEY_PATCHES, "Dependencies to patch", ValueType.INT)
       .setDescription("Dependencies with patches to apply")
       .setDirection(Metric.DIRECTION_WORST)
       .setQualitative(Boolean.TRUE)
@@ -109,7 +116,15 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
       .setBestValue(0.0)
       .create();
 
-  static final Metric<Double> PATCHES_RATIO = new Metric.Builder(Metrics.KEY_PATCHES_RATIO, "Dependencies to patch (Ratio)", ValueType.PERCENT)
+  private static final Metric<String> PATCHES_DATA = new Metric.Builder(Metrics.KEY_PATCHES_DATA, "List of patches", ValueType.STRING)
+      .setDescription("All dependencies to patch concatenated in a list")
+      .setDirection(Metric.DIRECTION_NONE)
+      .setQualitative(false)
+      .setDomain(Metrics.DOMAIN)
+      .setHidden(true)
+      .create();
+
+  private static final Metric<Double> PATCHES_RATIO = new Metric.Builder(Metrics.KEY_PATCHES_RATIO, "Dependencies to patch (Ratio)", ValueType.PERCENT)
       .setDescription("Ratio of dependencies with patches")
       .setDirection(Metric.DIRECTION_WORST)
       .setQualitative(Boolean.TRUE)
@@ -117,7 +132,7 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
       .setBestValue(0.0)
       .create();
 
-  static final Metric<Integer> PATCHES_MISSED = new Metric.Builder(Metrics.KEY_PATCHES_MISSED, "Patches missed", ValueType.INT)
+  private static final Metric<Integer> PATCHES_MISSED = new Metric.Builder(Metrics.KEY_PATCHES_MISSED, "Patches missed", ValueType.INT)
       .setDescription("Total number of releases patches missed")
       .setDirection(Metric.DIRECTION_WORST)
       .setQualitative(Boolean.TRUE)
@@ -125,7 +140,7 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
       .setBestValue(0.0)
       .create();
 
-  static final Metric<Integer> UPGRADES = new Metric.Builder(Metrics.KEY_UPGRADES, "Dependencies to upgrade", ValueType.INT)
+  private static final Metric<Integer> UPGRADES = new Metric.Builder(Metrics.KEY_UPGRADES, "Dependencies to upgrade", ValueType.INT)
       .setDescription("Dependencies with upgrades to apply")
       .setDirection(Metric.DIRECTION_WORST)
       .setQualitative(Boolean.TRUE)
@@ -133,7 +148,15 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
       .setBestValue(0.0)
       .create();
 
-  static final Metric<Double> UPGRADES_RATIO = new Metric.Builder(Metrics.KEY_UPGRADES_RATIO, "Dependencies to upgrade (Ratio)", ValueType.PERCENT)
+  private static final Metric<String> UPGRADES_DATA = new Metric.Builder(Metrics.KEY_UPGRADES_DATA, "List of upgrades", ValueType.STRING)
+      .setDescription("All dependencies to upgrade concatenated in a list")
+      .setDirection(Metric.DIRECTION_NONE)
+      .setQualitative(false)
+      .setDomain(Metrics.DOMAIN)
+      .setHidden(true)
+      .create();
+
+  private static final Metric<Double> UPGRADES_RATIO = new Metric.Builder(Metrics.KEY_UPGRADES_RATIO, "Dependencies to upgrade (Ratio)", ValueType.PERCENT)
       .setDescription("Ratio of dependencies with upgrades")
       .setDirection(Metric.DIRECTION_WORST)
       .setQualitative(Boolean.TRUE)
@@ -141,7 +164,7 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
       .setBestValue(0.0)
       .create();
 
-  static final Metric<Integer> UPGRADES_REPEATEDLY = new Metric.Builder(Metrics.KEY_UPGRADES_MISSED, "Upgrades missed", ValueType.INT)
+  private static final Metric<Integer> UPGRADES_REPEATEDLY = new Metric.Builder(Metrics.KEY_UPGRADES_MISSED, "Upgrades missed", ValueType.INT)
       .setDescription("Total number of released upgrades missed")
       .setDirection(Metric.DIRECTION_WORST)
       .setQualitative(Boolean.TRUE)
@@ -149,7 +172,7 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
       .setBestValue(0.0)
       .create();
 
-  static final Metric<Integer> PATCHES_RATING = new Metric.Builder(Metrics.KEY_PATCHES_RATING, "Patch Maintenance", ValueType.RATING)
+  private static final Metric<Integer> PATCHES_RATING = new Metric.Builder(Metrics.KEY_PATCHES_RATING, "Patch Maintenance", ValueType.RATING)
       .setDescription("Rating of the maintenance of applying patches")
       .setDirection(Metric.DIRECTION_BETTER)
       .setQualitative(Boolean.TRUE)
@@ -158,7 +181,7 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
       .setBestValue(1.0)
       .create();
 
-  static final Metric<Integer> UPGRADES_RATING = new Metric.Builder(Metrics.KEY_UPGRADES_RATING, "Upgrade Maintenance", ValueType.RATING)
+  private static final Metric<Integer> UPGRADES_RATING = new Metric.Builder(Metrics.KEY_UPGRADES_RATING, "Upgrade Maintenance", ValueType.RATING)
       .setDescription("Rating of the maintenance of applying upgrades")
       .setDirection(Metric.DIRECTION_BETTER)
       .setQualitative(Boolean.TRUE)
@@ -170,7 +193,7 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
   /**
    * Calculates all metrics provided by this Sonar-Plugin based on the given Analysis.
    */
-  public static void calculateMetricsModule(SensorContext context, Analysis analysis) {
+  static void calculateMetricsModule(SensorContext context, Analysis analysis) {
     calculateMetrics(context, context.fileSystem().inputFile(context.fileSystem().predicates().hasRelativePath("pom.xml")), analysis);
   }
 
@@ -183,10 +206,18 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
     calculateUpgrades(context, inputComponent, analysis);
     calculateUpgradesRatio(context, inputComponent, analysis);
     calculateUpgradesMissed(context, inputComponent, analysis);
+    calculateData(context, inputComponent, Metrics.DEPENDENCIES_DATA, analysis.all());
+    calculateData(context, inputComponent, Metrics.PATCHES_DATA, analysis.all().stream().filter(dependency -> dependency.getUpdateCount() > 0).collect(Collectors.toList()));
+    calculateData(context, inputComponent, Metrics.UPGRADES_DATA, analysis.all().stream().filter(dependency -> dependency.getUpgradeCount() > 0).collect(Collectors.toList()));
   }
 
   private static void calculateDependencies(SensorContext context, InputComponent inputComponent, Analysis analysis) {
     context.<Integer>newMeasure().forMetric(Metrics.DEPENDENCIES).on(inputComponent).withValue(analysis.all().size()).save();
+  }
+
+  private static void calculateData(SensorContext context, InputComponent inputComponent, Metric<String> metric, List<Dependency> dependencies) {
+    String dependenciesList = dependencies.stream().map(Dependency::toDataString).collect(Collectors.joining(","));
+    context.<String>newMeasure().forMetric(metric).on(inputComponent).withValue(dependenciesList).save();
   }
 
   private static void calculatePatches(SensorContext context, InputComponent inputComponent, Analysis analysis) {
@@ -206,18 +237,18 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
   }
 
   private static void calculatePatchesMissed(SensorContext context, InputComponent inputComponent, Analysis analysis) {
-    int sum = Math.toIntExact(analysis.all().stream().collect(Collectors.summarizingInt(Dependency::getUpdates)).getSum());
+    int sum = Math.toIntExact(analysis.all().stream().collect(Collectors.summarizingInt(Dependency::getUpdateCount)).getSum());
     context.<Integer>newMeasure().forMetric(Metrics.PATCHES_MISSED).on(inputComponent).withValue(sum).save();
   }
 
   private static void calculateUpgrades(SensorContext context, InputComponent inputComponent, Analysis analysis) {
-    int count = Math.toIntExact(analysis.all().stream().filter(dependency -> dependency.getUpgrades() > 0).count());
+    int count = Math.toIntExact(analysis.all().stream().filter(dependency -> dependency.getUpgradeCount() > 0).count());
     context.<Integer>newMeasure().forMetric(Metrics.UPGRADES).on(inputComponent).withValue(count).save();
   }
 
   private static void calculateUpgradesRatio(SensorContext context, InputComponent inputComponent, Analysis analysis) {
     double ratio = 0;
-    long totalDependenciesWithUpgrades = analysis.all().stream().filter(dependency -> dependency.getUpgrades() > 0).count();
+    long totalDependenciesWithUpgrades = analysis.all().stream().filter(dependency -> dependency.getUpgradeCount() > 0).count();
     if (analysis.all().size() > 0) {
       ratio = 100.0 * totalDependenciesWithUpgrades / analysis.all().size();
     }
@@ -227,7 +258,7 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
   }
 
   private static void calculateUpgradesMissed(SensorContext context, InputComponent inputComponent, Analysis analysis) {
-    int sum = Math.toIntExact(analysis.all().stream().collect(Collectors.summarizingInt(Dependency::getUpgrades)).getSum());
+    int sum = Math.toIntExact(analysis.all().stream().collect(Collectors.summarizingInt(Dependency::getUpgradeCount)).getSum());
     context.<Integer>newMeasure().forMetric(Metrics.UPGRADES_REPEATEDLY).on(inputComponent).withValue(sum).save();
   }
 
@@ -241,11 +272,14 @@ public final class Metrics implements org.sonar.api.measures.Metrics {
   public List<Metric> getMetrics() {
     return Arrays.asList(
         Metrics.DEPENDENCIES,
+        Metrics.DEPENDENCIES_DATA,
         Metrics.PATCHES,
+        Metrics.PATCHES_DATA,
         Metrics.PATCHES_RATIO,
         Metrics.PATCHES_MISSED,
         Metrics.PATCHES_RATING,
         Metrics.UPGRADES,
+        Metrics.UPGRADES_DATA,
         Metrics.UPGRADES_RATIO,
         Metrics.UPGRADES_REPEATEDLY,
         Metrics.UPGRADES_RATING

--- a/mathan-dependency-updates-sonar-plugin/src/main/java/io/mathan/sonar/dependencyupdates/parser/Dependency.java
+++ b/mathan-dependency-updates-sonar-plugin/src/main/java/io/mathan/sonar/dependencyupdates/parser/Dependency.java
@@ -79,11 +79,17 @@ public class Dependency {
     return minors;
   }
 
-  public int getUpdates() {
+  public List<String> getUpgrades() {
+    List<String> upgrades = new ArrayList<>(this.minors);
+    upgrades.addAll(majors);
+    return upgrades;
+  }
+
+  public int getUpdateCount() {
     return incrementals.size();
   }
 
-  public int getUpgrades() {
+  public int getUpgradeCount() {
     return minors.size() + majors.size();
   }
 
@@ -190,5 +196,12 @@ public class Dependency {
   @Override
   public String toString() {
     return String.format("%s:%s:%s", groupId, artifactId, version);
+  }
+
+  /**
+   * Creates a String identifying this dependency in format <i>groupId</i>:<i>artifactId</i>:<i>version</i>:<i>updates</i>:<i>upgrades</i>
+   */
+  public String toDataString() {
+    return String.format("%s:%s:%s:%s:%s", groupId, artifactId, version, getUpdateCount(), getUpgradeCount());
   }
 }

--- a/mathan-dependency-updates-sonar-plugin/src/test/groovy/io/mathan/sonar/dependencyupdates/DependencyUpdatesMeasureComputerSpec.groovy
+++ b/mathan-dependency-updates-sonar-plugin/src/test/groovy/io/mathan/sonar/dependencyupdates/DependencyUpdatesMeasureComputerSpec.groovy
@@ -42,7 +42,7 @@ class DependencyUpdatesMeasureComputerSpec extends Specification {
     MeasureComputer.MeasureComputerContext context = context(dependenciesA, dependenciesB)
     computer.compute(context)
     assert context.getMeasure(Metrics.KEY_DEPENDENCIES).intValue == dependencies
-    assert sorted(dependenciesData).equals(sorted(context.getMeasure(Metrics.KEY_DEPENDENCIES_DATA).stringValue))
+    assert sorted(dependenciesData) == sorted(context.getMeasure(Metrics.KEY_DEPENDENCIES_DATA).stringValue)
     where:
     dependenciesA | dependenciesB | dependencies | dependenciesData
     ""            | ""            | 0            | ""
@@ -77,7 +77,7 @@ class DependencyUpdatesMeasureComputerSpec extends Specification {
     assert context.getMeasure(Metrics.KEY_PATCHES_RATIO).doubleValue == patchesRatio
     assert context.getMeasure(Metrics.KEY_PATCHES_RATING).intValue == patchesRating
     assert context.getMeasure(Metrics.KEY_PATCHES_MISSED).intValue == patchesMissed
-    assert sorted(patchesData).equals(sorted(context.getMeasure(Metrics.KEY_PATCHES_DATA).stringValue))
+    assert sorted(patchesData) == sorted(context.getMeasure(Metrics.KEY_PATCHES_DATA).stringValue)
     where:
     dependenciesA | dependenciesB | patchesA    | patchesB    | patches | patchesData           | patchesRatio | patchesRating | patchesMissed
     ""            | ""            | ""          | ""          | 0       | ""                    | 0.0          | 1             | 0
@@ -112,7 +112,7 @@ class DependencyUpdatesMeasureComputerSpec extends Specification {
     assert context.getMeasure(Metrics.KEY_UPGRADES_RATIO).doubleValue == upgradesRatio
     assert context.getMeasure(Metrics.KEY_UPGRADES_RATING).intValue == upgradesRating
     assert context.getMeasure(Metrics.KEY_UPGRADES_MISSED).intValue == upgradesMissed
-    assert sorted(upgradesData).equals(sorted(context.getMeasure(Metrics.KEY_UPGRADES_DATA).stringValue))
+    assert sorted(upgradesData) == sorted(context.getMeasure(Metrics.KEY_UPGRADES_DATA).stringValue)
     where:
     dependenciesA | dependenciesB | upgradesA   | upgradesB   | upgrades | upgradesData          | upgradesRatio | upgradesRating | upgradesMissed
     ""            | ""            | ""          | ""          | 0        | ""                    | 0.0           | 1              | 0

--- a/mathan-dependency-updates-sonar-plugin/src/test/groovy/io/mathan/sonar/dependencyupdates/DependencyUpdatesMeasureComputerSpec.groovy
+++ b/mathan-dependency-updates-sonar-plugin/src/test/groovy/io/mathan/sonar/dependencyupdates/DependencyUpdatesMeasureComputerSpec.groovy
@@ -169,7 +169,7 @@ class DependencyUpdatesMeasureComputerSpec extends Specification {
    * Returns the list of dependencies sorted naturally.
    */
   String sorted(String dependencies) {
-    Set<String> sorted = new TreeSet<>();
+    Set<String> sorted = new TreeSet<>()
     Arrays.asList(dependencies.split(",")).forEach({ dependency -> sorted.add(dependency) })
     return String.join(",", sorted)
   }

--- a/mathan-dependency-updates-sonar-plugin/src/test/groovy/io/mathan/sonar/dependencyupdates/DependencyUpdatesMeasureComputerSpec.groovy
+++ b/mathan-dependency-updates-sonar-plugin/src/test/groovy/io/mathan/sonar/dependencyupdates/DependencyUpdatesMeasureComputerSpec.groovy
@@ -1,0 +1,176 @@
+/*
+ * mathan-dependency-updates-sonar-plugin
+ * Copyright (c) 2019 Matthias Hanisch
+ * matthias@mathan.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mathan.sonar.dependencyupdates
+
+import org.sonar.api.ce.measure.Component
+import org.sonar.api.ce.measure.MeasureComputer
+import org.sonar.api.ce.measure.test.TestComponent
+import org.sonar.api.ce.measure.test.TestMeasureComputerContext
+import org.sonar.api.ce.measure.test.TestMeasureComputerDefinition
+import org.sonar.api.ce.measure.test.TestSettings
+import spock.lang.Specification
+
+class DependencyUpdatesMeasureComputerSpec extends Specification {
+
+  /**
+   * Tests if metrics {@link Metrics#KEY_DEPENDENCIES} and {@link Metrics#KEY_DEPENDENCIES_DATA} are comuted properly based on the measures of child elements.
+   * - measures of all children have to be taken into account
+   * - only unique dependencies have to be taken into account
+   * @param dependenciesA The measure {@link Metrics#KEY_DEPENDENCIES_DATA} for child A.
+   * @param dependenciesB The measure {@link Metrics#KEY_DEPENDENCIES_DATA} for child B.
+   * @param dependencies The expected value for measure {@link Metrics#KEY_DEPENDENCIES}.
+   * @param dependenciesData The expected value for measure {@link Metrics#KEY_DEPENDENCIES_DATA}.
+   */
+  def dependencies(String dependenciesA, String dependenciesB, int dependencies, String dependenciesData) {
+    expect:
+    DependencyUpdatesMeasureComputer computer = new DependencyUpdatesMeasureComputer()
+    MeasureComputer.MeasureComputerContext context = context(dependenciesA, dependenciesB)
+    computer.compute(context)
+    assert context.getMeasure(Metrics.KEY_DEPENDENCIES).intValue == dependencies
+    assert sorted(dependenciesData).equals(sorted(context.getMeasure(Metrics.KEY_DEPENDENCIES_DATA).stringValue))
+    where:
+    dependenciesA | dependenciesB | dependencies | dependenciesData
+    ""            | ""            | 0            | ""
+    "a:b:c:0:0"   | ""            | 1            | "a:b:c:0:0"
+    ""            | "a:b:c:0:0"   | 1            | "a:b:c:0:0"
+    "a:b:c:0:0"   | "a:b:c:0:0"   | 1            | "a:b:c:0:0"
+    "a:b:c:0:0"   | "a:b:c:1:0"   | 2            | "a:b:c:0:0,a:b:c:1:0"
+    "a:b:c:0:0"   | "d:e:f:0:0"   | 2            | "a:b:c:0:0,d:e:f:0:0"
+  }
+
+  /**
+   * Tests if metrics {@link Metrics#KEY_PATCHES}, {@link Metrics#KEY_PATCHES_DATA}, {@link Metrics#KEY_PATCHES_RATIO}, {@link Metrics#KEY_PATCHES_RATING} and {@link Metrics#KEY_PATCHES_MISSED} are
+   * computed properly based on the measures of child elements.
+   * - measures of all children have to be taken into account
+   * - only unique dependencies have to be taken into account
+   * @param dependenciesA The measure {@link Metrics#KEY_DEPENDENCIES_DATA} for child A.
+   * @param dependenciesB The measure {@link Metrics#KEY_DEPENDENCIES_DATA} for child B.
+   * @param patchesA The measure {@link Metrics#PATCHES_DATA} for child A.
+   * @param patchesB The measure {@link Metrics#PATCHES_DATA} for child B.
+   * @param patches The expected value for measure {@link Metrics#KEY_PATCHES}.
+   * @param patchesData The expected value for measure {@link Metrics#KEY_PATCHES_DATA}.
+   * @param patchesRatio The expected value for measure {@link Metrics#KEY_PATCHES_RATIO}.
+   * @param patchesRating The expected value for measure {@link Metrics#KEY_PATCHES_RATING}.
+   * @param patchesMissed The expected value for measure {@link Metrics#KEY_PATCHES_MISSED}.
+   */
+  def patches(String dependenciesA, String dependenciesB, String patchesA, String patchesB, int patches, String patchesData, int patchesRatio, int patchesRating, int patchesMissed) {
+    expect:
+    DependencyUpdatesMeasureComputer computer = new DependencyUpdatesMeasureComputer()
+    MeasureComputer.MeasureComputerContext context = context(dependenciesA, dependenciesB, patchesA, patchesB, null, null)
+    computer.compute(context)
+    assert context.getMeasure(Metrics.KEY_PATCHES).intValue == patches
+    assert context.getMeasure(Metrics.KEY_PATCHES_RATIO).doubleValue == patchesRatio
+    assert context.getMeasure(Metrics.KEY_PATCHES_RATING).intValue == patchesRating
+    assert context.getMeasure(Metrics.KEY_PATCHES_MISSED).intValue == patchesMissed
+    assert sorted(patchesData).equals(sorted(context.getMeasure(Metrics.KEY_PATCHES_DATA).stringValue))
+    where:
+    dependenciesA | dependenciesB | patchesA    | patchesB    | patches | patchesData           | patchesRatio | patchesRating | patchesMissed
+    ""            | ""            | ""          | ""          | 0       | ""                    | 0.0          | 1             | 0
+    "a:b:c:1:0"   | ""            | "a:b:c:1:0" | ""          | 1       | "a:b:c:1:0"           | 100.0        | 2             | 1
+    "a:b:c:1:0"   | "a:b:c:1:0"   | "a:b:c:1:0" | "a:b:c:1:0" | 1       | "a:b:c:1:0"           | 100.0        | 2             | 1
+    "a:b:c:2:0"   | "a:b:c:2:0"   | "a:b:c:2:0" | "a:b:c:2:0" | 1       | "a:b:c:2:0"           | 100.0        | 2             | 2
+    "a:b:c:1:0"   | "a:b:c:2:0"   | "a:b:c:1:0" | "a:b:c:2:0" | 2       | "a:b:c:1:0,a:b:c:2:0" | 100.0        | 3             | 3
+    "a:b:c:4:0"   | "a:b:c:0:0"   | "a:b:c:4:0" | ""          | 1       | "a:b:c:4:0"           | 50.0         | 2             | 4
+  }
+
+  /**
+   * Tests if metrics {@link Metrics#KEY_UPGRADES}, {@link Metrics#KEY_UPGRADES_DATA}, {@link Metrics#KEY_UPGRADES_RATIO}, {@link Metrics#KEY_UPGRADES_RATING} and {@link Metrics#KEY_UPGRADES_MISSED}
+   * are computed properly based on the measures of child elements.
+   * - measures of all children have to be taken into account
+   * - only unique dependencies have to be taken into account
+   * @param dependenciesA The measure {@link Metrics#KEY_DEPENDENCIES_DATA} for child A.
+   * @param dependenciesB The measure {@link Metrics#KEY_DEPENDENCIES_DATA} for child B.
+   * @param upgradesA The measure {@link Metrics#PATCHES_DATA} for child A.
+   * @param upgradesB The measure {@link Metrics#PATCHES_DATA} for child B.
+   * @param patches The expected value for measure {@link Metrics#KEY_UPGRADES}.
+   * @param upgradesData The expected value for measure {@link Metrics#KEY_UPGRADES_DATA}.
+   * @param upgradesRatio The expected value for measure {@link Metrics#KEY_UPGRADES_RATIO}.
+   * @param upgradesRating The expected value for measure {@link Metrics#KEY_UPGRADES_RATING}.
+   * @param upgradesMissed The expected value for measure {@link Metrics#KEY_UPGRADES_MISSED}.
+   */
+  def upgrades(String dependenciesA, String dependenciesB, String upgradesA, String upgradesB, int upgrades, String upgradesData, int upgradesRatio, int upgradesRating, int upgradesMissed) {
+    expect:
+    DependencyUpdatesMeasureComputer computer = new DependencyUpdatesMeasureComputer()
+    MeasureComputer.MeasureComputerContext context = context(dependenciesA, dependenciesB, null, null, upgradesA, upgradesB)
+    computer.compute(context)
+    assert context.getMeasure(Metrics.KEY_UPGRADES).intValue == upgrades
+    assert context.getMeasure(Metrics.KEY_UPGRADES_RATIO).doubleValue == upgradesRatio
+    assert context.getMeasure(Metrics.KEY_UPGRADES_RATING).intValue == upgradesRating
+    assert context.getMeasure(Metrics.KEY_UPGRADES_MISSED).intValue == upgradesMissed
+    assert sorted(upgradesData).equals(sorted(context.getMeasure(Metrics.KEY_UPGRADES_DATA).stringValue))
+    where:
+    dependenciesA | dependenciesB | upgradesA   | upgradesB   | upgrades | upgradesData          | upgradesRatio | upgradesRating | upgradesMissed
+    ""            | ""            | ""          | ""          | 0        | ""                    | 0.0           | 1              | 0
+    "a:b:c:0:1"   | ""            | "a:b:c:0:1" | ""          | 1        | "a:b:c:0:1"           | 100.0         | 2              | 1
+    "a:b:c:0:1"   | "a:b:c:0:1"   | "a:b:c:0:1" | "a:b:c:0:1" | 1        | "a:b:c:0:1"           | 100.0         | 2              | 1
+    "a:b:c:0:2"   | "a:b:c:0:2"   | "a:b:c:0:2" | "a:b:c:0:2" | 1        | "a:b:c:0:2"           | 100.0         | 2              | 2
+    "a:b:c:0:1"   | "a:b:c:0:2"   | "a:b:c:0:1" | "a:b:c:0:2" | 2        | "a:b:c:0:1,a:b:c:0:2" | 100.0         | 3              | 3
+    "a:b:c:0:4"   | "a:b:c:0:0"   | "a:b:c:0:4" | ""          | 1        | "a:b:c:0:4"           | 50.0          | 2              | 4
+  }
+
+  /**
+   * Creates a MeasureComputerContext with metric values for {@link Metrics#KEY_DEPENDENCIES_DATA}.
+   * @param dependenciesA The measure {@link Metrics#KEY_DEPENDENCIES_DATA} for child A.
+   * @param dependenciesB The measure {@link Metrics#KEY_DEPENDENCIES_DATA} for child B.
+   */
+  MeasureComputer.MeasureComputerContext context(String dependenciesA, String dependenciesB) {
+    return context(dependenciesA, dependenciesB, null, null, null, null)
+  }
+
+  /**
+   * Creates a MeasureComputerContext with metric values for {@link Metrics#KEY_DEPENDENCIES_DATA}, {@link Metrics#KEY_PATCHES_DATA} and {@link Metrics#KEY_UPGRADES_DATA}.
+   * @param dependenciesA The measure {@link Metrics#KEY_DEPENDENCIES_DATA} for child A.
+   * @param dependenciesB The measure {@link Metrics#KEY_DEPENDENCIES_DATA} for child B.
+   * @param patchesA The measure {@link Metrics#PATCHES_DATA} for child A.
+   * @param patchesB The measure {@link Metrics#PATCHES_DATA} for child B.
+   * @param upgradesA The measure {@link Metrics#PATCHES_DATA} for child A.
+   * @param upgradesB The measure {@link Metrics#PATCHES_DATA} for child B.
+   * @return
+   */
+  MeasureComputer.MeasureComputerContext context(String dependenciesA, String dependenciesB, String patchesA, String patchesB, String upgradesA, String upgradesB) {
+    TestComponent component = new TestComponent("key", Component.Type.DIRECTORY, null)
+    TestSettings settings = new TestSettings()
+    TestMeasureComputerDefinition.MeasureComputerDefinitionBuilderImpl builder = new TestMeasureComputerDefinition.MeasureComputerDefinitionBuilderImpl()
+    builder.setInputMetrics(
+        Metrics.KEY_DEPENDENCIES, Metrics.KEY_DEPENDENCIES_DATA, Metrics.KEY_PATCHES, Metrics.KEY_PATCHES_DATA, Metrics.KEY_PATCHES_MISSED, Metrics.KEY_PATCHES_RATING, Metrics.KEY_PATCHES_RATIO,
+        Metrics.KEY_UPGRADES, Metrics.KEY_UPGRADES_DATA, Metrics.KEY_UPGRADES_MISSED, Metrics.KEY_UPGRADES_RATING, Metrics.KEY_UPGRADES_RATIO)
+    builder.setOutputMetrics(
+        Metrics.KEY_DEPENDENCIES, Metrics.KEY_DEPENDENCIES_DATA, Metrics.KEY_PATCHES, Metrics.KEY_PATCHES_DATA, Metrics.KEY_PATCHES_MISSED, Metrics.KEY_PATCHES_RATING, Metrics.KEY_PATCHES_RATIO,
+        Metrics.KEY_UPGRADES, Metrics.KEY_UPGRADES_DATA, Metrics.KEY_UPGRADES_MISSED, Metrics.KEY_UPGRADES_RATING, Metrics.KEY_UPGRADES_RATIO)
+    MeasureComputer.MeasureComputerDefinition definition = builder.build()
+
+    TestMeasureComputerContext context = new TestMeasureComputerContext(component, settings, definition)
+    context.addChildrenMeasures(Metrics.KEY_DEPENDENCIES_DATA, dependenciesA, dependenciesB)
+    if (patchesA != null && patchesB != null) {
+      context.addChildrenMeasures(Metrics.KEY_PATCHES_DATA, patchesA, patchesB)
+    }
+    if (upgradesA != null && upgradesB != null) {
+      context.addChildrenMeasures(Metrics.KEY_UPGRADES_DATA, upgradesA, upgradesB)
+    }
+    return context
+  }
+
+  /**
+   * Returns the list of dependencies sorted naturally.
+   */
+  String sorted(String dependencies) {
+    Set<String> sorted = new TreeSet<>();
+    Arrays.asList(dependencies.split(",")).forEach({ dependency -> sorted.add(dependency) })
+    return String.join(",", sorted)
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>io.mathan.sonar</groupId>
     <artifactId>mathan-dependency-updates-sonar-plugin-reactor</artifactId>
-    <version>7.6.0-SNAPSHOT</version>
+    <version>7.9.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
         <license.name>AL2</license.name>


### PR DESCRIPTION
When using multi-module build, dependencies used in multiple modules get reported multiple times in the parent module. This should be avoided.